### PR TITLE
Issue 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/examples

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
-name=EH_LED
+name=EH900 Library
 version=1.0
-author=Various
+author=EagleTechnology
 maintainer=Masa
 sentence=Drives level meter hardware
 paragraph=needs level meter.

--- a/src/EH_LED.h
+++ b/src/EH_LED.h
@@ -81,7 +81,7 @@ class EH_LED {
         * @return   true:指示受付   false:指示却下
         */
         bool turnOn(void){
-            while(busy_now){asm("nop");}
+            // while(busy_now){asm("nop");}
             LED_state=true;
             busy_now = true;
             return true;
@@ -93,7 +93,7 @@ class EH_LED {
         * @return   true:指示受付   false:指示却下
         */
         bool turnOff(void){
-            while(busy_now){asm("nop");}
+            // while(busy_now){asm("nop");}
             LED_state=false;
             busy_now = true;
             return true;

--- a/src/EH_switch.h
+++ b/src/EH_switch.h
@@ -121,14 +121,16 @@ class EH_switch {
 
         /// @brief スイッチの操作が通常のクリックかどうかを返す
         /// @return True:クリック
-        /// @note isReleased()=Trueの場合に意味がある値を取ります
+        /// @note ”非推奨” isReleased()=Trueの場合に意味がある値を取ります
+        ///     detected()を使用してください。
         bool isClicked(void){
             return clicked;
         }
         
         /// @brief スイッチの操作が長押しかどうかを返す
         /// @return True:長押し
-        /// @note isReleased()=Trueの場合に意味がある値を取ります
+        /// @note ”非推奨” isReleased()=Trueの場合に意味がある値を取ります
+        ///     detected()を使用してください。
         bool isLongPressing(void){
             return long_press;
         }

--- a/src/EH_switch.h
+++ b/src/EH_switch.h
@@ -27,6 +27,15 @@
 
 class EH_switch {
     public:
+        /*!
+        * @brief スイッチの押下状況の一覧
+        */
+        enum class E_Operation : uint8_t{
+            CLICK = 0,
+            LONGPRESS,
+            DOUBLECLICK,
+            UNKNOWN
+        };
 
         /*!
          * @brief constructor   ポート番号を指定
@@ -122,6 +131,19 @@ class EH_switch {
         /// @note isReleased()=Trueの場合に意味がある値を取ります
         bool isLongPressing(void){
             return long_press;
+        }
+
+        /// @brief 検出したスイッチの操作の種別を返します
+        /// @return E_Operation型
+        /// @note isReleased()=Trueの場合に意味がある値を取ります
+        E_Operation detected(void){
+            if (clicked){
+                return E_Operation::CLICK;
+            }
+            if (long_press){
+                return E_Operation::LONGPRESS;
+            }
+            return E_Operation::UNKNOWN;
         }
 
         /*!

--- a/src/measUnitParameters.h
+++ b/src/measUnitParameters.h
@@ -1,0 +1,65 @@
+#ifndef _MEASUNITPARAMETERS_H_
+#define _MEASUNITPARAMETERS_H_
+
+// consts
+//  I2C adress 計測用のIC達
+    namespace I2C_ADDR{
+    constexpr uint16_t ADC            = 0x48;   // 電圧・電流計測
+    constexpr uint16_t CURRENT_ADJ    = 0x60;   // 電流源調整用DA
+    constexpr uint16_t V_MON          = 0x49;   // 電圧出力用DAコンバータ
+    constexpr uint16_t PIO            = 0x20;   // GPIO IC  電流on/off  電流源エラー読み込み
+    };
+
+// ADの読み値から電圧値を計算するための系数 [/ micro Volts/LSB]
+// 3.3V電源、差動計測（バイポーラ出力）を想定
+    namespace ADC_READOUT_VOLTAGE_COEFF{
+    constexpr float GAIN_TWOTHIRDS    = 187.506;  //  FS 6.144V * 1E6/32767
+    constexpr float GAIN_ONE          = 125.004;  //  FS 4.096V * 1E6/32767
+    constexpr float GAIN_TWO          = 62.5019;  //  FS 2.048V * 1E6/32767
+    constexpr float GAIN_FOUR         = 31.2510;  //  FS 1.024V * 1E6/32767
+    constexpr float GAIN_EIGHT        = 15.6255;  //  FS 0.512V * 1E6/32767
+    constexpr float GAIN_SIXTEEN      = 7.81274;  //  FS 0.256V * 1E6/32767
+    };
+
+//  PIO関連 定数
+    namespace PIO_PORT{
+    //  PIOのポート番号の設定と論理レベル設定
+    constexpr uint16_t CURRENT_ENABLE    = 4 ;  // ON = LOW,  OFF = HIGH
+    constexpr uint16_t CURRENT_ERRFLAG   = 0 ;  // LOW = FAULT(short or open), HIGH = NOMAL
+    };
+
+    // 電流源コントロールロジック定義
+    constexpr uint16_t CURRENT_OFF  = HIGH ;    // Current off when GPIO=HIGH
+    constexpr uint16_t CURRENT_ON   = LOW ;     // Current on when GPIO=LOW
+
+//  計測に使う定数
+    //  センサの単位長あたりのインピーダンス[ohm/inch]
+    constexpr float SENSOR_UNIT_IMP = 11.6;
+
+    //  センサの熱伝導速度  測定待ち時間の計算に必要  inch/s
+    constexpr float HEAT_PROPERGATION_VEROCITY = 7.9; 
+
+    // 電流計測時の電流電圧変換係数(R=5kohm, Coeff_Isenosr=0.004(0.2/50ohm)の時) [/ V/A]
+    constexpr float CURRENT_MEASURE_COEFF = 20.000;
+
+    //  電圧計測のアッテネータ系数  1/10 x 2/5 の逆数  実際の抵抗値での計算
+    constexpr float ATTENUATOR_COEFF = 24.6642;
+
+    // AD変換時の平均化回数 １回測るのに10msかかるので注意  10回で100ms
+    constexpr uint16_t ADC_AVERAGE_DEFAULT = 10;
+
+    //  電流源調整用DAC MCP4725 1Vあたりの電流[0.1mA/V] 56==5.6mA/V
+    constexpr uint16_t  CURRENT_SORCE_VI_COEFF  = 56; 
+
+    //  電流源調整用DAC MCP4275の1Vあたりのカウント (3.3V電源にて） COUNT/V
+    constexpr uint16_t DAC_COUNT_PER_VOLT = 1241;
+
+    //  Vmon用  DAC80501 1Vあたりのカウント(2.5VFS時）  COUNT/V
+    constexpr uint16_t VMON_COUNT_PER_VOLT = 26214;
+
+    // 計測用定数
+    //  連続計測時の計測周期
+    constexpr uint16_t CONT_MEAS_INTERVAL = 100; // [x10ms]
+
+
+#endif //_MEASUNITPARAMETERS_H_

--- a/src/measurement.cpp
+++ b/src/measurement.cpp
@@ -22,10 +22,10 @@ void Measurement::init(void){
         single_meas_interval = single_meas_period/3;//[CLK count]   
     }
 
-    Serial.println(sensor_heat_propagation_time);
-    Serial.print("Sensor Length:"); Serial.println(p_parameter->sensor_length);
-    Serial.print("Delay Time:"); Serial.println(sensor_heat_propagation_time);
-    Serial.print("Sensor R:"); Serial.println(sensor_resistance);
+    if(DEBUG){Serial.println(sensor_heat_propagation_time);}
+    if(DEBUG){Serial.print("Sensor Length:"); Serial.println(p_parameter->sensor_length);}
+    if(DEBUG){Serial.print("Delay Time:"); Serial.println(sensor_heat_propagation_time);}
+    if(DEBUG){Serial.print("Sensor R:"); Serial.println(sensor_resistance);}
     // デバイスの校正値を設定
     // デバイスの校正値はFramから読み込まれてp_parameterに入っているのでそこを直接読む
     
@@ -83,7 +83,7 @@ void Measurement::clk_in(void){
             if ( (single_meas_counter % single_meas_interval) == 0){
                 single_last_meas = false;
                 should_measure = true;
-                Serial.print("preMeas ");
+                if(DEBUG){Serial.print("preMeas ");}
             }
         }else{
             // 最終の計測：ここでの計測が測定値として保持される
@@ -96,7 +96,7 @@ void Measurement::clk_in(void){
                 single_last_meas = true;
                 should_measure = true;
                 // exec_single_measurement = false;
-                Serial.print("lastMeas ");
+                if(DEBUG){Serial.print("lastMeas ");}
             }
         };
     };
@@ -135,16 +135,16 @@ void Measurement::setCommand(Measurement::ECommand command){
             present_mode = EModes::MANUAL;
             busy_now = true;
             if (currentOn()){
-                Serial.print("SINGLE Start. ");Serial.println(micros());
+                if(DEBUG){Serial.print("SINGLE Start. ");Serial.println(micros());}
                 single_meas_counter = 0;
                 sensor_error = false;
             }else{
-                Serial.println("SINGLE Meas ERROR. terminate");
+                if(DEBUG){Serial.println("SINGLE Meas ERROR. terminate");}
                 sensor_error = true;
                 terminateMeasurement();
             }
         } else {
-            Serial.println("Fail: measure command while busy.");
+            if(DEBUG){Serial.println("Fail: measure command while busy.");}
         }
         break;
 
@@ -153,15 +153,15 @@ void Measurement::setCommand(Measurement::ECommand command){
             present_mode = EModes::CONTINUOUS;
             busy_now = true;
             if (currentOn()){
-                Serial.println("CONT Start.");
+                if(DEBUG){Serial.println("CONT Start.");}
                 sensor_error = false;
             } else {
-                Serial.println("CONT Meas ERROR. terminate");
+                if(DEBUG){Serial.println("CONT Meas ERROR. terminate");}
                 sensor_error = true;
                 terminateMeasurement();
             }
         } else {
-            Serial.println("Fail: measure command while busy.");
+            if(DEBUG){Serial.println("Fail: measure command while busy.");}
         }
         break;
     
@@ -169,28 +169,28 @@ void Measurement::setCommand(Measurement::ECommand command){
         if(busy_now){
             terminateMeasurement();
         } else {
-            Serial.println("Fail: CONT END command while ready.");
+            if(DEBUG){Serial.println("Fail: CONT END command while ready.");}
         }
         break;
 
     case Measurement::ECommand::TERMINATE :
         if(busy_now){
-            Serial.println("TERMINATE.");
+            if(DEBUG){Serial.println("TERMINATE.");}
             terminateMeasurement();
         } else {
-            Serial.println("Fail: TERMINATE command while ready.");
+            if(DEBUG){Serial.println("Fail: TERMINATE command while ready.");}
         }
 
         break;
 
     case Measurement::ECommand::IDLE :
-        Serial.print("busy:");Serial.print(busy_now);Serial.print(" - error:");Serial.print(sensor_error);
+        if(DEBUG){Serial.print("busy:");Serial.print(busy_now);Serial.print(" - error:");Serial.print(sensor_error);}
         // Serial.print(" - cont:");Serial.println(exec_cont_measurement);
-        Serial.println("Measurement status did not change.");
+        if(DEBUG){Serial.println("Measurement status did not change.");}
         break;
 
     default:
-        Serial.println("ERROR: NO COMMAND");
+        if(DEBUG){Serial.println("ERROR: NO COMMAND");}
         break;
     }
 }
@@ -208,7 +208,7 @@ void Measurement::executeMeasurement(void){
     bool the_last_meas = single_last_meas;
 
     // for debug
-    Serial.print("execMeas::start "); Serial.print(micros());Serial.print(" ");
+    if(DEBUG){Serial.print("execMeas::start "); Serial.print(micros());Serial.print(" ");}
 
     uint16_t result = 0;
     if (getCurrentSourceStatus()){
@@ -220,9 +220,9 @@ void Measurement::executeMeasurement(void){
 
     // Sensorエラー処理（異常終了）
     if (sensor_error){
-        Serial.print("-sensorError  - ");
+        if(DEBUG){Serial.print("-sensorError  - ");}
         //センサエラー（測定中にエラー発生）なら計測を終了して帰る
-        Serial.println("Measurement Treminate by error.");
+        if(DEBUG){Serial.println("Measurement Treminate by error.");}
         terminateMeasurement();
         
         // Vmonにエラーを出力
@@ -232,7 +232,7 @@ void Measurement::executeMeasurement(void){
 
     // 一回計測の最終計測の場合は一回計測のクロージング処理
     if (the_last_meas){
-        Serial.print("-single:last- ");
+        if(DEBUG){Serial.print("-single:last- ");}
         single_last_meas = false;
         single_meas_counter = 0;
         should_measure = false;//最終計測なので、計測中に入った測定要求は無視する
@@ -246,14 +246,14 @@ void Measurement::executeMeasurement(void){
     // フラグを出力(フラグ、getter必要)
     // 結果を出力（getter必要）
 
-    Serial.println("execMeas::End ");
+    if(DEBUG){Serial.println("execMeas::End ");}
 }
 
 /*!
  * @brief 電流源をonにする
  */
 bool Measurement::currentOn(void){
-    Serial.println("CurrentSoruce ON");
+    if(DEBUG){Serial.println("CurrentSoruce ON");}
     return true;
 
     // FOR TEST
@@ -272,7 +272,7 @@ bool Measurement::currentOn(void){
  * @brief 電流源をoffにする
  */
 void Measurement::currentOff(void){
-    Serial.println("CurrentSoruce OFF");
+    if(DEBUG){Serial.println("CurrentSoruce OFF");}
     return ;
 }
 
@@ -281,7 +281,7 @@ void Measurement::currentOff(void){
  * @param current 設定電流値[0.1mA]
  */
 void Measurement::setCurrent(uint16_t current){
-    Serial.print("CurrentSoruce set");Serial.println(current);
+    if(DEBUG){Serial.print("CurrentSoruce set");Serial.println(current);}
     return;
 }
 
@@ -290,7 +290,7 @@ void Measurement::setCurrent(uint16_t current){
  * @returns True: 電流Onの設定で正常に電流を供給している, False:電流がoff もしくは 負荷異常
  */
 bool Measurement::getCurrentSourceStatus(void){
-    Serial.print("C-C ");
+    if(DEBUG){Serial.print("C-C ");}
     return true;
     // // FOR TESST
     // return false;
@@ -318,19 +318,19 @@ void Measurement::terminateMeasurement(void){
 /// @return uint16_t 液面 [0.1%] 
 uint16_t Measurement::read_level(void){
     delay(150);// 計測に必要な時間のダミー
-    Serial.print("RL ");
+    if(DEBUG){Serial.print("RL ");}
     return 1234;
 }
 
 /// @brief 電圧モニタ出力を設定する 
 /// @param vout 出力電圧[0.1V] 
 void Measurement::setVmon(uint16_t vout){
-    Serial.print("Vout: set");Serial.println(vout);
+    if(DEBUG){Serial.print("Vout: set");Serial.println(vout);}
     return;
 }
 
 /// @brief  電圧モニタ出力にエラーを提示する（0V) 
 /// @param  void
 void Measurement::setVmonFailed(void){
-    Serial.println("Vout: Error indicate.");    
+    if(DEBUG){Serial.println("Vout: Error indicate.");}    
 }

--- a/src/measurement.cpp
+++ b/src/measurement.cpp
@@ -155,6 +155,8 @@ void Measurement::clk_in(void){
             } else {
                 sensor_error = true;
             }
+            present_mode = EModes::TIMER;
+            busy_now = false;
             single_measurement = false;
         };
         if (sensor_error){

--- a/src/measurement.cpp
+++ b/src/measurement.cpp
@@ -3,66 +3,7 @@
 */
 
 #include "measurement.h"
-
-// consts
-//  I2C adress 計測用のIC達
-    namespace I2C_ADDR{
-    constexpr uint16_t ADC            = 0x48;   // 電圧・電流計測
-    constexpr uint16_t CURRENT_ADJ    = 0x60;   // 電流源調整用DA
-    constexpr uint16_t V_MON          = 0x49;   // 電圧出力用DAコンバータ
-    constexpr uint16_t PIO            = 0x20;   // GPIO IC  電流on/off  電流源エラー読み込み
-    };
-
-// ADの読み値から電圧値を計算するための系数 [/ micro Volts/LSB]
-// 3.3V電源、差動計測（バイポーラ出力）を想定
-    namespace ADC_READOUT_VOLTAGE_COEFF{
-    constexpr float GAIN_TWOTHIRDS    = 187.506;  //  FS 6.144V * 1E6/32767
-    constexpr float GAIN_ONE          = 125.004;  //  FS 4.096V * 1E6/32767
-    constexpr float GAIN_TWO          = 62.5019;  //  FS 2.048V * 1E6/32767
-    constexpr float GAIN_FOUR         = 31.2510;  //  FS 1.024V * 1E6/32767
-    constexpr float GAIN_EIGHT        = 15.6255;  //  FS 0.512V * 1E6/32767
-    constexpr float GAIN_SIXTEEN      = 7.81274;  //  FS 0.256V * 1E6/32767
-    };
-
-//  PIO関連 定数
-    namespace PIO_PORT{
-    //  PIOのポート番号の設定と論理レベル設定
-    constexpr uint16_t CURRENT_ENABLE    = 4 ;  // ON = LOW,  OFF = HIGH
-    constexpr uint16_t CURRENT_ERRFLAG   = 0 ;  // LOW = FAULT(short or open), HIGH = NOMAL
-    };
-
-    // 電流源コントロールロジック定義
-    constexpr uint16_t CURRENT_OFF  = HIGH ;    // Current off when GPIO=HIGH
-    constexpr uint16_t CURRENT_ON   = LOW ;     // Current on when GPIO=LOW
-
-//  計測に使う定数
-    //  センサの単位長あたりのインピーダンス[ohm/inch]
-    constexpr float SENSOR_UNIT_IMP = 11.6;
-
-    //  センサの熱伝導速度  測定待ち時間の計算に必要  inch/s
-    constexpr float HEAT_PROPERGATION_VEROCITY = 7.9; 
-
-    // 電流計測時の電流電圧変換係数(R=5kohm, Coeff_Isenosr=0.004(0.2/50ohm)の時) [/ V/A]
-    constexpr float CURRENT_MEASURE_COEFF = 20.000;
-
-    //  電圧計測のアッテネータ系数  1/10 x 2/5 の逆数  実際の抵抗値での計算
-    constexpr float ATTENUATOR_COEFF = 24.6642;
-
-    // AD変換時の平均化回数 １回測るのに10msかかるので注意  10回で100ms
-    constexpr uint16_t ADC_AVERAGE_DEFAULT = 10;
-
-    //  電流源調整用DAC MCP4725 1Vあたりの電流[0.1mA/V] 56==5.6mA/V
-    constexpr uint16_t  CURRENT_SORCE_VI_COEFF  = 56; 
-
-    //  電流源調整用DAC MCP4275の1Vあたりのカウント (3.3V電源にて） COUNT/V
-    constexpr uint16_t DAC_COUNT_PER_VOLT = 1241;
-
-    //  Vmon用  DAC80501 1Vあたりのカウント(2.5VFS時）  COUNT/V
-    constexpr uint16_t VMON_COUNT_PER_VOLT = 26214;
-
-    // 計測用定数
-    //  連続計測時の計測周期
-    constexpr uint16_t CONT_MEAS_INTERVAL = 100; // [x10ms]
+#include "measUnitParameters.h"
 
 // Methodの実体
 
@@ -365,6 +306,7 @@ bool Measurement::getCurrentSourceStatus(void){
  * @brief 測定を終了する
  */
 void Measurement::terminateMeasurement(void){
+    should_measure = false;
     currentOff();
     present_mode = EModes::TIMER;
     busy_now = false;

--- a/src/measurement.h
+++ b/src/measurement.h
@@ -32,7 +32,8 @@ class Measurement {
         IDLE = 0,
         SINGLE,
         CONTSTART,
-        CONTEND
+        CONTEND,
+        TERMINATE
     };
 
     /*!
@@ -97,6 +98,9 @@ class Measurement {
 
     // 実際の測定を実行
     void executeMeasurement(void);
+    bool shouldMeasure(void){
+        return should_measure;
+    }
 
     EModes getMode(void){
         return present_mode;
@@ -140,32 +144,22 @@ class Measurement {
     bool busy_now = false;
 
     //  外部への測定指示フラグ
-    bool shoud_measure = false; 
+    bool should_measure = false; 
 
     // 連続計測動作
-    bool cont_measurement = false;
     uint16_t cont_meas_inteval_counter = 0;
 
      // 一回計測動作
-    bool single_measurement = false;
     uint16_t single_meas_counter = 0;
     uint16_t single_meas_interval = 0;
     uint16_t single_meas_period = 0;
     bool single_last_meas = false;
 
-
-    // 表示停止依頼
-    bool inhibit_lcd_refresh = false;
-
     //  現在の動作モードを保持
     EModes present_mode = EModes::TIMER;
 
     // methods 
-    // 高機能計測
-    //  液面を計測（シングル）
-    bool measSingle(void);
-    bool contSTART(void);
-    bool contEND(void);
+    void terminateMeasurement(void);
 
     //  電圧・電流値の読み取り
     uint32_t read_voltage(void);

--- a/src/measurement.h
+++ b/src/measurement.h
@@ -14,6 +14,8 @@
 #ifndef _MEASUREMENT_H_
 #define _MEASUREMENT_H_
 
+#include <Arduino.h>
+
 // デバイスのドライバ
 #include <Adafruit_ADS1015.h>   // ADC 16bit diff - 2ch
 #include <Adafruit_MCP23008.h>  // PIO 8bit

--- a/src/measurement.h
+++ b/src/measurement.h
@@ -121,6 +121,9 @@ class Measurement {
     private:
     // consts
 
+    // debug flag
+    constexpr static bool DEBUG = true;
+
     // instances
     // デバイスのインスタンスへのポインタ 
     //  電流設定用DAコンバータ

--- a/src/measurement.h
+++ b/src/measurement.h
@@ -95,6 +95,9 @@ class Measurement {
 
     void setCommand(Measurement::ECommand command);
 
+    // 実際の測定を実行
+    void executeMeasurement(void);
+
     EModes getMode(void){
         return present_mode;
     };
@@ -136,6 +139,9 @@ class Measurement {
     // リソースが命令実行中
     bool busy_now = false;
 
+    //  外部への測定指示フラグ
+    bool shoud_measure = false; 
+
     // 連続計測動作
     bool cont_measurement = false;
     uint16_t cont_meas_inteval_counter = 0;
@@ -145,6 +151,7 @@ class Measurement {
     uint16_t single_meas_counter = 0;
     uint16_t single_meas_interval = 0;
     uint16_t single_meas_period = 0;
+    bool single_last_meas = false;
 
 
     // 表示停止依頼

--- a/src/statemachine.cpp
+++ b/src/statemachine.cpp
@@ -1,0 +1,106 @@
+#include "statemachine.h"
+
+
+/// @brief ステートマシンの状態に応じた文字を返します（表示用）
+/// @param  void
+/// @return ModeIndで定義した文字の中の1文字が状態に応じて返されます
+char Statemachine::getStatusChar(void){
+    return ModeInd[static_cast<uint8_t>(machine_status)];
+}
+
+
+/*!
+    * @brief 状態遷移のためのトリガ信号を与えます
+    * @param  Statemachine::ETransit型   状態遷移のための信号名
+    * @return true: statusが更新された false: 更新なし
+    * @note 計測コマンド(command)もこの中でセットされる
+    */
+bool Statemachine::setTransitSignal(ETransit signal){
+
+  // for test
+  Serial.print("(Signal:");
+  // 
+  previous_machine_status = machine_status;
+  bool update = true;  
+
+  switch (signal) {
+    case ETransit::CLICK :
+      Serial.print("CLICK)");
+      if(machine_status == EStatus::TIMER){
+        machine_status = EStatus::MANUAL;
+        command = EMeasCommand::SINGLE;
+      }
+      // else if(machine_status == EStatus::MANUAL){
+      //   machine_status = EStatus::TIMER;
+      // }
+      else if(machine_status == EStatus::CONT){
+        machine_status = EStatus::TIMER;
+        command = EMeasCommand::CONTEND;
+      } else {
+        update = false;
+        command = EMeasCommand::IDLE;
+        }
+    break;
+
+    case ETransit::LONG :
+      Serial.print("LONG)");
+      if (machine_status == EStatus::TIMER){
+        machine_status = EStatus::CONT;
+        command = EMeasCommand::CONTSTART;
+      } else if (machine_status == EStatus::CONT){
+        machine_status = EStatus::TIMER;
+        command = EMeasCommand::CONTEND;
+      } else {
+        update = false;
+        command = EMeasCommand::IDLE;
+        }   
+    break;
+      
+    case ETransit::TIMEUP :
+      Serial.print("TIMEUP)");
+      if(machine_status == EStatus::TIMER){
+        machine_status = EStatus::MANUAL;
+        command = EMeasCommand::SINGLE;
+      } else {
+        update = false;
+        command = EMeasCommand::IDLE;
+        }   
+    break;
+      
+    case ETransit::MEASCPL :
+      Serial.print("MEAS end)");
+      if(machine_status == EStatus::MANUAL){
+        machine_status = EStatus::TIMER;
+      } else {
+        update = false;
+        command = EMeasCommand::IDLE;
+        }   
+    break;
+
+    case ETransit::IDLE :
+      Serial.print("IDLE)");
+      update = false;
+      command = EMeasCommand::IDLE;
+    break;
+
+    default:
+      update = false;
+      command = EMeasCommand::IDLE;
+    break;
+  }
+  
+  // for test
+  // Serial.println(static_cast<uint8_t>(machine_status));
+  // 
+
+  Statemachine::updated = (previous_machine_status != machine_status);
+
+  return (updated);
+}
+
+/// @brief 状態遷移に応じた計測部への指示を返します
+/// @return EMeasCommand型 測定命令
+/// @note isChanged()==true 時に有効になります
+Statemachine::EMeasCommand Statemachine::getMeasCommand(void){
+    return command;
+}

--- a/src/statemachine.h
+++ b/src/statemachine.h
@@ -1,0 +1,122 @@
+/**************************************************************************/
+/*!
+ * @file statemachine.h
+ * @brief EH-900 動作モード制御用ステートマシン
+ * @author Masakazu Miyamoto
+ * @date 2022/8/1-
+ * $Version:    0.0$
+ * @par History
+ *    
+ * 
+ */
+/**************************************************************************/
+
+#ifndef _EH_statemachine_H_
+#define _EH_statemachine_H_
+
+#include <Arduino.h>
+
+/*!
+ * @class   Statemachine
+ * @brief   EH-900 動作モード制御用ステートマシン
+ *          
+ * 
+ */
+class Statemachine {
+
+    public:
+        /// @brief ステートマシンの状態遷移イベント一覧
+        enum class ETransit : uint8_t{
+            IDLE = 0,
+            CLICK,  //  操作スイッチ  クリック
+            LONG,   //  操作スイッチ  長押し
+            TIMEUP, //  タイマ計測
+            MEASCPL //  測定完了
+        };
+
+        // @brief ステートマシン状態一覧
+        enum class EStatus : uint8_t {
+            TIMER = 0,
+            MANUAL,
+            CONT
+        };
+
+        /// @brief モード表示のための文字配列（EStatusと連携）
+        const char ModeInd[3]={'T','M','C'};
+
+        enum class EMeasCommand : uint8_t{
+            IDLE = 0,
+            SINGLE,
+            CONTSTART,
+            CONTEND
+        };
+
+        /*!
+         * @brief constructor   
+         */
+        Statemachine(){
+        };
+    
+        /*!
+         * @brief deconstructor
+         *  
+         */
+        ~Statemachine(){
+        };
+
+
+        /*!
+         * @brief マシンの内部状態を返します
+         * @param  
+         * @return EStatus型 
+         */
+        EStatus getStatus(void){
+            return machine_status;
+        };
+
+        /// @brief ステートマシンの状態に応じた文字を返します（表示用）
+        /// @param  void
+        /// @return ModeIndで定義した文字の中の1文字が状態に応じて返されます
+        char getStatusChar(void);
+
+
+        /*!
+         * @brief 状態遷移のためのトリガ信号を与えます
+         * @param  Etransit型   状態遷移のための信号名
+         * @return true: statusが更新された false: 更新なし
+         * @note 
+         */
+        bool setTransitSignal(ETransit signal);
+
+        /*!
+         * @brief 状態遷移が行われたかどうかを返します
+         * @return true: statusが更新された false: 更新なし
+         * @note 読み取るたびに値はクリアされます
+         */
+        bool hasStatuUpdated(void){
+            bool temp_flag = updated;
+            updated = false;
+            return temp_flag;
+        };
+
+        /// @brief 状態遷移に応じた計測部への指示を返します
+        /// @return EMeasCommand型 測定命令
+        /// @note isChanged()==true 時に有効になります
+        EMeasCommand getMeasCommand(void);
+        
+
+    private:
+
+        EStatus machine_status = EStatus::TIMER;
+        EStatus previous_machine_status = EStatus::TIMER;
+
+        bool updated = false;
+
+        EMeasCommand command = EMeasCommand::IDLE;
+
+
+};
+
+
+
+#endif //_EH_statemachine_H_


### PR DESCRIPTION
計測時のI2Cのバスの利用率は把握できた。
電圧計測に100ms、電流計測に100msひつようで、共に連続的にバスを占有する。

そのため、LCDの表示割り込みをAD変換時に停止するように指示を出せるようにする。

また、計測指示の変更を行う。
モード設定と、そのモードでの測定開始・終了をコマンドとし、計測側から「完了」を受け取って次のモードへ移行できるようにする。