### PR TITLE
Feature/20231020/hardweare driving test

### DIFF
--- a/src/measurement.cpp
+++ b/src/measurement.cpp
@@ -537,7 +537,7 @@ uint16_t Measurement::read_level(void){
     if(DEBUG){Serial.print(" Ratio = "); Serial.println( ratio, 4 );}
     // センサの抵抗値誤差のマージンを2%とって確実にゼロ表示ができるようにする
     int16_t result = round((1.0 - ratio*1.02) * 1000);
-    level_scaling(result, 1.0, 0.0);
+    level_scaling(result, p_parameter->scale_100, p_parameter->scale_0);
     return (uint16_t)result;
 }
 
@@ -547,12 +547,13 @@ uint16_t Measurement::read_level(void){
 // @param lowside_scale:0%表示にする計測レベル (0.0--1.0) : default 0.0
 // @return 引数levelに返します
 // @note hiside_scle > lowside_scale の必要があります。
-void Measurement::level_scaling(int16_t& level, const float_t& hiside_scale, const float_t& lowside_scale){
+void Measurement::level_scaling(int16_t& level, const uint16_t& hiside_scale, const uint16_t& lowside_scale){
     if (hiside_scale < lowside_scale){return;}
-    if (hiside_scale < 0 or hiside_scale > 1.0 ){return;}
-    if (lowside_scale < 0 or lowside_scale > 1.0 ){return;}
-
-    level = (int16_t) ( ((float)level/1000.0 - lowside_scale)/(hiside_scale - lowside_scale) * 1000.0);
+    if (hiside_scale < 0 or hiside_scale > 1000 ){return;}
+    if (lowside_scale < 0 or lowside_scale > 1000 ){return;}
+    if(DEBUG){Serial.print(" scaling = "); Serial.print( hiside_scale ); Serial.print(":"); Serial.println(lowside_scale);}
+    
+    level = (int16_t) ( (float)(level - lowside_scale)/(float)(hiside_scale - lowside_scale) * 1000.0);
     // limitter
     if(level > 1000){
         level = 1000;

--- a/src/measurement.cpp
+++ b/src/measurement.cpp
@@ -14,44 +14,83 @@ void Measurement::init(void){
     sensor_heat_propagation_time = p_parameter->sensor_length * (uint16_t)(1/HEAT_PROPERGATION_VEROCITY * 1000.0 * 1.2); // [ms]
     single_meas_period = sensor_heat_propagation_time/10;//[CLK count, clk=10ms cycle]
     // 一回計測時の伝搬時間内の計測周期を決める 3回計測することを基本にする
-    // ！！要検討！！   6インチぐらいの短いセンサだと伝搬時間内に３回測定できない
-    //      0.5秒ぐらいのLowlimitを設ける
+    // 6インチぐらいの短いセンサだと伝搬時間内に３回測定できないので、最短で0.5秒とし、それをlimitとする
     if (single_meas_period < 150){ // 1.5秒より短い伝搬時間の場合
         single_meas_interval = 50; // 0.5s周期
     } else{
         single_meas_interval = single_meas_period/3;//[CLK count]   
     }
 
-    if(DEBUG){Serial.print("Sensor Length[inch]:"); Serial.println(p_parameter->sensor_length);}
-    if(DEBUG){Serial.print("Delay Time:"); Serial.println(sensor_heat_propagation_time);}
-    if(DEBUG){Serial.print("Sensor R:"); Serial.println(sensor_resistance);}
+    if(DEBUG){
+        Serial.print("Sensor Length[inch]:"); Serial.println(p_parameter->sensor_length);
+        Serial.print("Delay Time:"); Serial.println(sensor_heat_propagation_time);
+        Serial.print("Sensor R:"); Serial.println(sensor_resistance);
+        Serial.print("TimerPeriod: "); Serial.println(p_parameter->timer_period);
+        Serial.print("setCurrent: "); Serial.println(p_parameter->current_set_default);
+        Serial.print("VmonDA_offset: "); Serial.println(p_parameter->vmon_da_offset);
+    }
     // デバイスの校正値を設定
     // デバイスの校正値はFramから読み込まれてp_parameterに入っているのでそこを直接読む
     
     // deviceドライバのインスタンス作成、初期化
-    // たとえば
-    // if(pio){
-    //     delete pio;
-    // }
-    // pio = new Adafruit_MCP23008;
-    // if (pio->begin(I2C_ADDR::PIO, &Wire)) { 
-    //     //  set IO port 
-    //     pio->pinMode(PIO_PORT::CURRENT_ERRFLAG, INPUT);
-    //     pio->pullUp(PIO_PORT::CURRENT_ERRFLAG, HIGH);  // turn on a 100K pullup internally
 
-    //     pio->pinMode(PIO_PORT::CURRENT_ENABLE, OUTPUT);
-    //     pio->digitalWrite(PIO_PORT::CURRENT_ENABLE, CURRENT_OFF);
-    // } else {
-    //     Serial.println("error on PIO.  ");
-    //     f_init_succeed = false;
-    // }
-    
+    bool f_init_succeed = true;
+
+    // 電流源設定用DAC  初期化
+    if(current_adj_dac){delete current_adj_dac;}
+    current_adj_dac = new Adafruit_MCP4725;
+    if (current_adj_dac->begin(I2C_ADDR::CURRENT_ADJ, &Wire)) { 
+        // 電流値設定
+        setCurrent(p_parameter->current_set_default);
+    } else {
+        if(DEBUG){Serial.println("error on Current Source DAC.  ");}
+        f_init_succeed = false;
+    }
+
+    // アナログモニタ用DAC  初期化
+    if(v_mon_dac){delete v_mon_dac;}
+    v_mon_dac = new DAC80501;
+    if (v_mon_dac->begin(I2C_ADDR::V_MON, &Wire)) { 
+         if (v_mon_dac->init()) { 
+            // アナログモニタ出力   リセット 
+            setVmon(0);
+        } else {
+            if(DEBUG){Serial.println("error on Analog Monitor DAC.  ");}
+            f_init_succeed = false;
+        }
+    } else {
+        if(DEBUG){Serial.println("error on Analog Monitor DAC.  ");}
+        f_init_succeed = false;
+    }
+
+    // PIO  初期化
+    if(pio){delete pio;}
+    pio = new Adafruit_MCP23008;
+    if (pio->begin(I2C_ADDR::PIO, &Wire)) { 
+        //  set IO port 
+        pio->pinMode(PIO_PORT::CURRENT_ERRFLAG, INPUT);
+        pio->pullUp(PIO_PORT::CURRENT_ERRFLAG, HIGH);  // turn on a 100K pullup internally
+
+        pio->pinMode(PIO_PORT::CURRENT_ENABLE, OUTPUT);
+        pio->digitalWrite(PIO_PORT::CURRENT_ENABLE, CURRENT_OFF);
+    } else {
+        if(DEBUG){Serial.println("error on PIO.  ");}
+        f_init_succeed = false;
+    }
+
+    //  計測用ADコンバータ設定    PGA=x2   2.048V FS
+    if(meas_adc){delete meas_adc;}
+    meas_adc = new Adafruit_ADS1115(I2C_ADDR::ADC);
+    meas_adc->begin();
+    meas_adc->setGain(adsGain_t::GAIN_TWO); 
+
     // 確認として、インスタンスのアドレスとサイズを印字
-    // Serial.print("DA-current:"); Serial.print((uint32_t)current_adj_dac,HEX); Serial.print("/");Serial.println(sizeof(*current_adj_dac));
-    // Serial.print("DA-Vmon:"); Serial.print((uint32_t)v_mon_dac,HEX); Serial.print("/");Serial.println(sizeof(*v_mon_dac));
-    // Serial.print("PIO:"); Serial.print((uint32_t)pio,HEX); Serial.print("/");Serial.println(sizeof(*pio));
-    // Serial.print("ADC:"); Serial.print((uint32_t)adconverter,HEX); Serial.print("/");Serial.println(sizeof(*adconverter));
-    // Serial.print("eh900:"); Serial.print((uint32_t)LevelMeter,HEX); Serial.print("/");Serial.println(sizeof(*LevelMeter));
+    if(DEBUG){
+        Serial.print("DA-current:"); Serial.print((uint32_t)current_adj_dac,HEX); Serial.print("/");Serial.println(sizeof(*current_adj_dac));
+        Serial.print("DA-Vmon:"); Serial.print((uint32_t)v_mon_dac,HEX); Serial.print("/");Serial.println(sizeof(*v_mon_dac));
+        Serial.print("PIO:"); Serial.print((uint32_t)pio,HEX); Serial.print("/");Serial.println(sizeof(*pio));
+        Serial.print("ADC:"); Serial.print((uint32_t)meas_adc,HEX); Serial.print("/");Serial.println(sizeof(*meas_adc));
+    }
 
 
 }  
@@ -289,8 +328,26 @@ uint16_t Measurement::getResult(void){
  * @brief 電流源をonにする
  */
 bool Measurement::currentOn(void){
-    if(DEBUG){Serial.println("CurrentSoruce ON");}
+    // if(DEBUG){Serial.println("CurrentSoruce ON");}
+
+
+    Serial.print("currentCtrl:ON -- "); 
+    pio->digitalWrite(PIO_PORT::CURRENT_ENABLE, CURRENT_ON);
+    delay(10); // エラー判定が可能になるまで10ms待つ
+    
+    if (pio->digitalRead(PIO_PORT::CURRENT_ERRFLAG) == LOW){
+        // f_sensor_error = true;
+        pio->digitalWrite(PIO_PORT::CURRENT_ENABLE, CURRENT_OFF);
+        Serial.print(" FAIL.  ");
+    } else {
+        // f_sensor_error = false;
+        delay(100); // issue1: 電流のステイブルを待つ
+        Serial.print(" OK.  ");
+    }
+    Serial.println("Fin. --");
+
     return true;
+
 
     // FOR TEST
     // return false;
@@ -308,7 +365,10 @@ bool Measurement::currentOn(void){
  * @brief 電流源をoffにする
  */
 void Measurement::currentOff(void){
-    if(DEBUG){Serial.println("CurrentSoruce OFF");}
+    // if(DEBUG){Serial.println("CurrentSoruce OFF");}
+    Serial.print("currentCtrl:OFF  -- ");
+    pio->digitalWrite(PIO_PORT::CURRENT_ENABLE, CURRENT_OFF);      
+    Serial.println(" Fin. --");
     return ;
 }
 
@@ -317,7 +377,14 @@ void Measurement::currentOff(void){
  * @param current 設定電流値[0.1mA]
  */
 void Measurement::setCurrent(uint16_t current){
-    if(DEBUG){Serial.print("CurrentSoruce set");Serial.println(current);}
+    if(DEBUG){Serial.print("CurrentSoruce set ");Serial.println(current);}
+    if ( 670 < current && current < 830){
+        uint16_t value = (( current - 666 ) * DAC_COUNT_PER_VOLT) / CURRENT_SORCE_VI_COEFF;
+        Serial.print(" value:"); Serial.print(value);
+        // current -> vref converting function
+        current_adj_dac->setVoltage(value, false);
+        Serial.println(" - DAC changed. " ); 
+      }
     return;
 }
 
@@ -341,7 +408,7 @@ bool Measurement::getCurrentSourceStatus(void){
 /// @brief 電圧モニタ出力を設定する 
 /// @param vout 出力電圧[0.1V] 
 void Measurement::setVmon(uint16_t vout){
-    if(DEBUG){Serial.print("Vout: set");Serial.println(vout);}
+    if(DEBUG){Serial.print("Vout: set ");Serial.println(vout);}
     return;
 }
 

--- a/src/measurement.h
+++ b/src/measurement.h
@@ -20,7 +20,7 @@
 #include <Adafruit_ADS1015.h>   // ADC 16bit diff - 2ch
 #include <Adafruit_MCP23008.h>  // PIO 8bit
 #include <Adafruit_MCP4725.h>   // DAC  12bit 
-// #include "DAC80501.h"           // DAC 16bit for Analog Mon Out
+#include "DAC80501.h"           // DAC 16bit for Analog Mon Out
 
 class Measurement {
 
@@ -137,13 +137,13 @@ class Measurement {
     // instances
     // デバイスのインスタンスへのポインタ 
     //  電流設定用DAコンバータ
-    // Adafruit_MCP4725*   current_adj_dac = nullptr;
+    Adafruit_MCP4725*   current_adj_dac = nullptr;
     // //  アナログモニタ出力用DAコンバータ
-    // DAC80501*           v_mon_dac = nullptr;
+    DAC80501*           v_mon_dac = nullptr;
     // //  電流源制御用    GPIO
-    // Adafruit_MCP23008*  pio = nullptr;
+    Adafruit_MCP23008*  pio = nullptr;
     // //  電圧・電流読み取り用ADコンバータ
-    // Adafruit_ADS1115*   adconverter = nullptr;
+    Adafruit_ADS1115*   meas_adc = nullptr;
 
     // vars
 

--- a/src/measurement.h
+++ b/src/measurement.h
@@ -51,7 +51,11 @@ class Measurement {
         uint8_t sensor_length;
         //  タイマ設定  [s]
         uint16_t timer_period;
-
+        //  スケーリング
+        //      100%表示をセンサ長の何%に設定するか [0.1%]
+        uint16_t scale_100 = 1000;
+        //      0%表示をセンサ長の何%に設定するか [0.1%]
+        uint16_t scale_0 = 0;
         //  計測ユニットの校正値
         //      ADコンバータのエラー補正系数    電圧計測
         float_t adc_err_comp_diff_0_1;
@@ -196,7 +200,7 @@ class Measurement {
     uint32_t read_voltage(void);
     uint32_t read_current(void);
     uint16_t read_level(void);
-    void level_scaling(int16_t& level, const float_t& hiside_scle = 1.0, const float_t& lowside_scale = 0.0);
+    void level_scaling(int16_t& level, const uint16_t& hiside_scle = 1000, const uint16_t& lowside_scale = 0);
 
 };
 

--- a/src/measurement.h
+++ b/src/measurement.h
@@ -174,6 +174,9 @@ class Measurement {
     uint16_t single_meas_period = 0;
     bool single_last_meas = false;
 
+    // 計測用ADCゲイン係数 mirco volt/LSB
+    float adc_gain_coeff = 0.0;
+
     //  現在の動作モードを保持
     EModes present_mode = EModes::TIMER;
 
@@ -189,6 +192,7 @@ class Measurement {
     void terminateMeasurement(void);
 
     //  電圧・電流値の読み取り
+    int32_t  read_raw_voltage(const uint8_t channel);
     uint32_t read_voltage(void);
     uint32_t read_current(void);
     uint16_t read_level(void);

--- a/src/measurement.h
+++ b/src/measurement.h
@@ -196,6 +196,7 @@ class Measurement {
     uint32_t read_voltage(void);
     uint32_t read_current(void);
     uint16_t read_level(void);
+    void level_scaling(int16_t& level, const float_t& hiside_scle = 1.0, const float_t& lowside_scale = 0.0);
 
 };
 

--- a/src/measurement.h
+++ b/src/measurement.h
@@ -92,40 +92,30 @@ class Measurement {
     void init(void);
     void clk_in(void);
 
-    /// @brief 計測クラスが動作中かどうか
-    /// @return True:測定可能   False:現在作業中
-    bool isReady(void){
-        return !busy_now;
-    };
+ 
 
     // ユニットの設定
     void setCommand(Measurement::ECommand command);
     void setMode(Measurement::EModes mode);
     EModes getMode(void);
 
-    // 実際の測定を実行
+    // 測定関連
+    bool isReady(void);
+    bool shouldMeasure(void);
     void executeMeasurement(void);
-    bool shouldMeasure(void){
-        return should_measure;
-    }
+    bool isSensorError(void); 
+    bool isResultReady(void); 
+    uint16_t getResult(void); 
 
-    //  外部への通知
-    bool shouldVacateI2Cbus(void);
+    //  statemachineへのフィードバック 
     bool haveFinishedMeasurement(void); //正常測定完了信号      statemachine用    モーメンタリ
     bool haveFailedMesasurement(void);  //測定開始エラー信号    statemachine用    モーメンタリ
-    bool isSensorError(void); //LCD表示用  オルタネート
-    bool isResultReady(void); // 測定結果が用意できているかどうかチェック   モーメンタリ
-    uint16_t getResult(void); // 測定結果の読み出し
 
-
-    //  電流源制御
-    bool currentOn(void);
-    void currentOff(void);
-    void setCurrent(uint16_t current = 750);
-    bool getCurrentSourceStatus(void);
+    //  I2Cバス制御
+    bool shouldVacateI2Cbus(void);
 
     //  モニタ出力制御
-    void setVmon(uint16_t vout);
+    void setVmon(const uint16_t vout);
     void setVmonFailed(void);
 
     private:
@@ -188,6 +178,14 @@ class Measurement {
     EModes present_mode = EModes::TIMER;
 
     // methods 
+
+    //  電流源制御
+    bool currentOn(void);
+    void currentOff(void);
+    void setCurrent(uint16_t current = 750);
+    bool getCurrentSourceStatus(void);
+
+    // 計測制御
     void terminateMeasurement(void);
 
     //  電圧・電流値の読み取り


### PR DESCRIPTION
- Measurementクラスにハードウエアのドライバを読み込ませるようにしました。
- 実際にデバイスとやり取りするコードを入れ、測定できるようにしました。
- 測定結果をスケーリングするmethodを追加しました。
- レベル（抵抗値）の測定は電流計測と電圧計測の２つで構成されますが、電流計測、電圧計測ともADCの読み取りはほぼ同じコードなので共通化しました。`read_raw_voltage()`

`IntegrationTest_SW_SM_MEAS.ino`および`daq_test.ino`でテスト済み。