### PR TITLE
add error code on init(), cont/single count bugfix

### DIFF
--- a/src/measurement.h
+++ b/src/measurement.h
@@ -93,7 +93,7 @@ class Measurement {
     };
 
 
-    void init(void);
+    uint16_t init(void);
     void clk_in(void);
 
  


### PR DESCRIPTION
テスト済
Measurementの初期化時にデバイスを発見できない場合、エラーコードを返すように設定
エラーコードでどのデバイスが発見できなかったかがわかるようにした
タイマ周期のカウントが間違っていたのを修正